### PR TITLE
Fix: Improve SDK build caching and DB table init order

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# Git specific
+.git/
+.gitignore
+
+# Docker specific (sometimes Dockerfile itself is ignored if not in root of context)
+# Dockerfile # Not ignoring this as it's at the root of the build context.
+
+# Python specific
+__pycache__/
+*.py[co]
+*.egg-info/
+.env
+.venv/
+env/
+venv/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Application Specific
+# Logs and captured images are runtime data, not part of the build
+app/logs/
+app/anpr_images/
+
+# SDK temporary directory and downloaded zip
+.sdk_temp/
+dahua_sdk.zip
+
+# Host setup script (not needed in image)
+setup.sh
+
+# READMEs and other markdown docs (optional, but saves image space)
+*.md
+# If GEMINI.md is useful within the image for some reason, comment the line above or make it more specific.
+# For now, assuming it's documentation not needed at runtime.
+
+# Example files that are not needed in the final image
+.env.example
+app/config.ini.example
+# app/run_listener.sh # This might be useful if it were an entrypoint, but current setup uses direct python/gunicorn calls.
+
+# Test files if any (none in current structure, but good practice)
+# tests/
+# *.test.py
+# pytest.ini
+# .coveragerc

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,12 @@ MYSQL_ROOT_PASSWORD=YOUR_ROOT_PASSWORD_HERE
 MYSQL_DATABASE=anpr_events
 MYSQL_USER=anpr_user
 MYSQL_PASSWORD=YOUR_USER_PASSWORD_HERE
+DB_HOST=mariadb
+
+# ANPR Service Settings
+# URL for anpr_listener to send events to anpr_db_manager
+DB_MANAGER_URL=http://anpr-db-manager:5001/event
+
+# Ports (mainly for documentation/consistency, Gunicorn binds override Flask dev server ports)
+DB_MANAGER_PORT=5001
+WEB_UI_PORT=5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.env
+.venv/
+env/
+venv/
+
+# IDE / Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Application Specific
+app/logs/.dependencies_checked
+# If anpr_images or logs directories on host should not be committed (they are volume mounts)
+# app/anpr_images/
+# app/logs/
+# (Uncomment above if you don't want to commit example images/logs, but often these dirs are empty in repo)
+
+# SDK temporary directory (if created locally and not just in setup.sh)
+.sdk_temp/
+
+# Dahua SDK zip file (if downloaded locally and not cleaned up by setup.sh)
+dahua_sdk.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,18 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the application code into the container
-# This assumes the .whl file is already in the 'app' directory on the host
-COPY ./app/ .
+# Copy the application code into the container (excluding the .whl file now, will be copied separately)
+COPY ./app/ /app/
 
 # Install the Dahua SDK and move its libraries
-RUN pip install *.whl && \
+# First, copy only the .whl file to a specific location to better leverage Docker cache.
+# This assumes there's only one .whl file in the app directory.
+COPY ./app/*.whl /tmp/sdk.whl
+RUN pip install /tmp/sdk.whl && \
     mkdir -p /usr/local/lib/dahua_sdk && \
-    cp /usr/local/lib/python3.11/site-packages/NetSDK/Libs/linux64/*.so /usr/local/lib/dahua_sdk/
+    cp /usr/local/lib/python3.11/site-packages/NetSDK/Libs/linux64/*.so /usr/local/lib/dahua_sdk/ && \
+    rm -f /tmp/sdk.whl && \
+    rm -f /app/*.whl # Clean up .whl from /app if it was copied by the broader COPY ./app/ /app/
 
 # Expose the web interface port
 EXPOSE 5000

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,78 @@
+# ANPR System Project Overview (GEMINI.MD)
+
+This document provides a high-level overview of the ANPR (Automatic Number Plate Recognition) system for quick context understanding by an LLM.
+
+## Core Objective
+
+The system captures license plate data (including images and metadata) from multiple Dahua ANPR cameras, stores this information in a MariaDB database, and provides a web interface for querying and viewing the captured data.
+
+## System Components
+
+The project is structured as a multi-component system orchestrated by Docker Compose:
+
+1.  **`anpr_listener` (`app/anpr_listener.py`)**
+    *   **Purpose**: Connects to Dahua ANPR cameras using the Dahua NetSDK.
+    *   **Functionality**:
+        *   Reads camera connection details from `app/config.ini`.
+        *   Subscribes to ANPR events from cameras.
+        *   On receiving an event, extracts plate number, timestamp, vehicle details, and the event image.
+        *   Sends this data (metadata as JSON, image as file) via an HTTP POST request to the `anpr_db_manager` service.
+        *   Designed for high speed and reliability; communication with `anpr_db_manager` is asynchronous (threaded) to prevent blocking.
+    *   **Key Technologies**: Python, Dahua NetSDK, `requests` library, `configparser`.
+
+2.  **`anpr_db_manager` (`app/anpr_db_manager.py`)**
+    *   **Purpose**: Manages the storage of ANPR event data and images.
+    *   **Functionality**:
+        *   A Flask web application exposing an HTTP API endpoint (typically `/event` on port 5001).
+        *   Receives event data (JSON) and image files from `anpr_listener`.
+        *   Saves received images to a shared volume (configured via `ImageDirectory` in `app/config.ini`, typically `/app/anpr_images`).
+        *   Inserts event metadata (including the filename of the saved image) into the `anpr_events` table in the MariaDB database.
+        *   Handles database connections and table creation/verification.
+    *   **Key Technologies**: Python, Flask, `mysql-connector-python`, `configparser`.
+
+3.  **`anpr_web` (`app/anpr_web.py`)**
+    *   **Purpose**: Provides the backend for the web-based user interface.
+    *   **Functionality**:
+        *   A Flask web application (typically running on port 5000).
+        *   Serves the main `index.html` page (`app/templates/index.html`).
+        *   Exposes several API endpoints that are consumed by `index.html`:
+            *   `/api/events`: Fetches ANPR events from MariaDB with support for filtering (plate, camera, vehicle type/color, direction, dates) and pagination.
+            *   `/api/cameras`: Provides a list of unique camera IDs found in the database.
+            *   `/api/events/latest_timestamp`: Returns the timestamp of the most recent event, used for notifying the user of new data.
+            *   `/images/<filename>`: Serves captured images stored in the shared image volume.
+    *   **Key Technologies**: Python, Flask, `mysql-connector-python`.
+
+4.  **`mariadb` (Docker Service)**
+    *   **Purpose**: The relational database used to store ANPR event metadata.
+    *   **Functionality**: Runs a MariaDB 10.6 instance. Data is persisted using a Docker named volume (`anpr_db_data`).
+    *   **Schema**: Contains the `anpr_events` table with columns for timestamp, plate number, camera ID, vehicle details, image filename, etc.
+
+5.  **`cloudflared-tunnel` (Docker Service)**
+    *   **Purpose**: Provides a secure reverse proxy tunnel to expose the `anpr_web` service to the internet via Cloudflare.
+    *   **Functionality**: Uses a Cloudflare token (from `.env`) to establish the tunnel.
+
+## Configuration
+
+*   **`.env` / `.env.example`**: Contains environment-specific settings like Cloudflare token and MariaDB credentials.
+*   **`app/config.ini` / `app/config.ini.example`**: Contains camera connection details (IPs, credentials, channels) and paths (e.g., `ImageDirectory`).
+*   **`docker-compose.yml`**: Defines how all services are built, configured, networked, and run.
+*   **`Dockerfile`**: Defines the common Docker image for the Python services, including Python environment, system dependencies, Dahua SDK installation, and application code copying.
+*   **`requirements.txt`**: Lists Python package dependencies (Flask, requests, mysql-connector-python, gunicorn).
+
+## Workflow Summary
+
+1.  `anpr_listener` connects to cameras specified in `config.ini`.
+2.  Upon detecting a license plate, the camera sends an event (with image) to `anpr_listener`.
+3.  `anpr_listener` processes this and forwards the data (JSON metadata + image file) to `anpr_db_manager`'s `/event` API endpoint.
+4.  `anpr_db_manager` saves the image to the `/app/anpr_images` volume and writes the event metadata (including image filename) to the MariaDB database.
+5.  The user accesses the web interface via the Cloudflare tunnel URL, which points to `anpr_web`.
+6.  `anpr_web` serves `index.html`, which then makes API calls to `anpr_web` itself to fetch and display event data from the database, including images.
+
+## Key File Locations
+
+*   Python application scripts: `app/`
+*   Web templates: `app/templates/`
+*   Docker configuration: `Dockerfile`, `docker-compose.yml`
+*   Host-mounted image storage (example): `./app/anpr_images/`
+*   Host-mounted log storage (example): `./app/logs/`
+*   Setup script: `setup.sh` (for host environment setup and service management)

--- a/app/anpr_db_manager.py
+++ b/app/anpr_db_manager.py
@@ -1,159 +1,316 @@
-import time, sys, logging, os, re, configparser, uuid
+import time, sys, logging, os, re, configparser, uuid, json, datetime
 import mysql.connector
+from flask import Flask, request, jsonify
+
+# --- Application Setup ---
+app = Flask(__name__)
 
 # --- Configuration Loading ---
 config = configparser.ConfigParser(interpolation=None)
-# Assuming config.ini will be in the same directory as anpr_poc.py or specified via an absolute path
-# For now, let's assume it's relative to where the script is run or we'll need to adjust this path.
-# For a robust solution, consider passing the config path or making it configurable.
-# For this PoC, we'll assume it's in the same directory as anpr_poc.py for simplicity.
-config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.ini')
-if not os.path.exists(config_path):
-    # Fallback for development/testing if config.ini is not in the same dir
-    config_path = '/app/config.ini' # Path used in anpr-camera-listener Docker setup
-    if not os.path.exists(config_path):
-        logging.error(f"config.ini not found at {os.path.dirname(os.path.abspath(__file__))} or /app/. Please ensure it exists.")
-        sys.exit(1)
+CONFIG_FILE_PATH = '/app/config.ini'  # Primary path for Docker
+if not os.path.exists(CONFIG_FILE_PATH):
+    CONFIG_FILE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.ini') # Fallback for local
 
-config.read(config_path)
+if not os.path.exists(CONFIG_FILE_PATH):
+    # Use basic logging if config file for logger is not found yet
+    logging.basicConfig(level=logging.ERROR)
+    logging.error(f"CRITICAL: config.ini not found at /app/config.ini or local path. Please ensure it exists.")
+    sys.exit(1)
+config.read(CONFIG_FILE_PATH)
 
-IMAGE_DIR = config.get('Paths', 'ImageDirectory', fallback=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'capturas'))
-LOG_FILE = config.get('General', 'LogFile', fallback=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'anpr_events.log'))
+# --- Global Variables & Paths from Config ---
+IMAGE_DIR = config.get('Paths', 'ImageDirectory', fallback='/app/anpr_images') # Default for Docker
+LOG_FILE_PATH = config.get('General', 'LogFile', fallback='/app/logs/anpr_db_manager.log') # Default for Docker
 
-# Ensure IMAGE_DIR exists
+# Ensure IMAGE_DIR and log directory exist
 os.makedirs(IMAGE_DIR, exist_ok=True)
+os.makedirs(os.path.dirname(LOG_FILE_PATH), exist_ok=True)
+
+
+# --- Logging Setup ---
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+log_formatter = logging.Formatter('%(asctime)s [%(levelname)s] [%(module)s:%(funcName)s:%(lineno)d] %(message)s')
+
+# File Handler
+file_handler = logging.FileHandler(LOG_FILE_PATH)
+file_handler.setFormatter(log_formatter)
+logger.addHandler(file_handler)
+
+# Console Handler
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setFormatter(log_formatter)
+logger.addHandler(console_handler)
+
 
 # --- Database Configuration ---
 DB_HOST = os.getenv('DB_HOST', 'mariadb')
 DB_USER = os.getenv('MYSQL_USER', 'anpr_user')
-DB_PASSWORD = os.getenv('MYSQL_PASSWORD')
+DB_PASSWORD = os.getenv('MYSQL_PASSWORD') # Should be set in .env
 DB_NAME = os.getenv('MYSQL_DATABASE', 'anpr_events')
 
-# --- Logging Setup ---
-log_formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
-# Ensure log directory exists before setting up handler
-if LOG_FILE:
-    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
-file_handler = logging.FileHandler(LOG_FILE)
-file_handler.setFormatter(log_formatter)
-file_handler.setLevel(logging.INFO)
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setFormatter(log_formatter)
-console_handler.setLevel(logging.INFO)
-logger = logging.getLogger(__name__) # Use __name__ for logger
-logger.setLevel(logging.INFO)
-if not logger.handlers: # Prevent adding multiple handlers if already configured
-    logger.addHandler(file_handler)
-    logger.addHandler(console_handler)
+if not DB_PASSWORD:
+    logger.critical("MYSQL_PASSWORD environment variable not set. Cannot connect to database.")
+    sys.exit(1)
 
-DB_CONNECTION = None
+DB_CONNECTION = None # Global database connection object
 
 def sanitize_filename(name_part):
     if not name_part or name_part == "N/A": return "NO_PLATE"
-    return re.sub(r'[\\/*?:"<>|]', "_", name_part)
+    return re.sub(r'[\\/*?:"<>| ]', "_", name_part) # Added space removal
 
 def initialize_database():
     global DB_CONNECTION
     attempts = 0
-    while attempts < 10:
+    max_attempts = 10 # Increased for robustness during startup
+    retry_delay = 5 # seconds
+
+    while attempts < max_attempts:
         try:
+            logger.info(f"Attempting to connect to database (Attempt {attempts + 1}/{max_attempts})...")
             conn = mysql.connector.connect(
                 host=DB_HOST,
                 user=DB_USER,
                 password=DB_PASSWORD,
-                database=DB_NAME
+                database=DB_NAME,
+                connection_timeout=10 # Added connection timeout
             )
             if conn.is_connected():
-                logger.info("Successfully connected to MariaDB database.")
+                logger.info(f"Successfully connected to MariaDB database: {DB_NAME} on {DB_HOST}")
                 DB_CONNECTION = conn
-                try:
-                    logger.info("Ensuring anpr_events table exists...")
-                    cursor = DB_CONNECTION.cursor()
-                    cursor.execute("""
-                        CREATE TABLE IF NOT EXISTS anpr_events (
-                            id INT AUTO_INCREMENT PRIMARY KEY,
-                            Timestamp DATETIME,
-                            PlateNumber VARCHAR(255),
-                            EventType VARCHAR(255),
-                            CameraID VARCHAR(255),
-                            VehicleType VARCHAR(255),
-                            VehicleColor VARCHAR(255),
-                            PlateColor VARCHAR(255),
-                            ImageFilename VARCHAR(255),
-                            DrivingDirection VARCHAR(255),
-                            ReceivedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                            INDEX idx_plate_number (PlateNumber),
-                            INDEX idx_camera_id (CameraID),
-                            INDEX idx_timestamp (Timestamp),
-                            INDEX idx_vehicle_type (VehicleType),
-                            INDEX idx_vehicle_color (VehicleColor),
-                            INDEX idx_driving_direction (DrivingDirection)
-                        )
-                    """)
-                    DB_CONNECTION.commit()
-                    cursor.close()
-                    logger.info("Table anpr_events ensured.")
-                except mysql.connector.Error as err_table:
-                    logger.error(f"Failed to create/ensure anpr_events table: {err_table}")
-                return
+                ensure_anpr_events_table() # Call table creation/check
+                return True
         except mysql.connector.Error as e:
-            logger.warning(f"Failed to connect to database: {e}. Retrying in 5 seconds...")
+            logger.warning(f"Failed to connect to database: {e}. Retrying in {retry_delay} seconds...")
             attempts += 1
-            time.sleep(5)
+            time.sleep(retry_delay)
     
     logger.critical("Could not connect to the database after multiple attempts. Exiting.")
-    sys.exit(1)
+    # sys.exit(1) # Consider if exiting is always desired or if app should run w/o DB temporarily
+    return False
+
+def ensure_anpr_events_table():
+    if DB_CONNECTION is None or not DB_CONNECTION.is_connected():
+        logger.error("Cannot ensure table, database not connected.")
+        return
+    try:
+        logger.info("Ensuring anpr_events table exists...")
+        cursor = DB_CONNECTION.cursor()
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS anpr_events (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                Timestamp DATETIME(3),
+                PlateNumber VARCHAR(50),
+                EventType VARCHAR(50),
+                CameraID VARCHAR(100),
+                VehicleType VARCHAR(50),
+                VehicleColor VARCHAR(50),
+                PlateColor VARCHAR(50),
+                ImageFilename VARCHAR(255),
+                DrivingDirection VARCHAR(50),
+                VehicleSpeed INT,
+                Lane INT,
+                ReceivedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                INDEX idx_plate_number (PlateNumber),
+                INDEX idx_camera_id (CameraID),
+                INDEX idx_timestamp (Timestamp),
+                INDEX idx_vehicle_type (VehicleType),
+                INDEX idx_vehicle_color (VehicleColor),
+                INDEX idx_driving_direction (DrivingDirection)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        """) # Added DATETIME(3) for milliseconds, increased some VARCHAR sizes, specified engine and charset
+        DB_CONNECTION.commit()
+        cursor.close()
+        logger.info("Table anpr_events ensured/created successfully.")
+    except mysql.connector.Error as err_table:
+        logger.error(f"Failed to create/ensure anpr_events table: {err_table}", exc_info=True)
+
+
+def get_db_connection():
+    """Gets a new DB connection or pings existing one. Reconnects if necessary."""
+    global DB_CONNECTION
+    try:
+        if DB_CONNECTION is None or not DB_CONNECTION.is_connected():
+            logger.info("Database connection lost or not initialized. Attempting to reconnect...")
+            initialize_database()
+        else:
+            # Ping the connection to ensure it's alive
+            DB_CONNECTION.ping(reconnect=True, attempts=3, delay=1)
+            logger.debug("Database connection is active.")
+        return DB_CONNECTION
+    except mysql.connector.Error as e:
+        logger.error(f"Database connection check failed: {e}. Attempting to re-initialize.")
+        initialize_database() # Try to re-establish
+        return DB_CONNECTION # Return whatever state it's in (might be None)
+
 
 def insert_anpr_event_db(event_data):
-    if DB_CONNECTION is None or not DB_CONNECTION.is_connected():
-        logger.warning("DB_CONNECTION is not available. Attempting to reconnect...")
-        initialize_database()
-        if DB_CONNECTION is None or not DB_CONNECTION.is_connected():
-            logger.error("Failed to re-establish database connection. Cannot insert event.")
-            return
+    conn = get_db_connection()
+    if conn is None or not conn.is_connected():
+        logger.error("Failed to get active database connection. Cannot insert event.")
+        return False
 
-    sql = '''INSERT INTO anpr_events (Timestamp, PlateNumber, EventType, CameraID, VehicleType, VehicleColor, PlateColor, ImageFilename, DrivingDirection)
-             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)'''
+    # Ensure all expected fields are present, providing defaults for missing optional fields
+    # This matches the anpr_listener event_details structure
+    sql_columns = [
+        "Timestamp", "PlateNumber", "EventType", "CameraID",
+        "VehicleType", "VehicleColor", "PlateColor", "ImageFilename",
+        "DrivingDirection", "VehicleSpeed", "Lane"
+    ]
+
+    # Prepare data tuple, using .get() with None as default for potentially missing fields
+    data_tuple = (
+        event_data.get("timestamp_capture"), # From listener: "timestamp_capture"
+        event_data.get("plate_number", "").strip(),
+        event_data.get("event_type"),
+        event_data.get("camera_id"),
+        event_data.get("vehicle_type"),
+        event_data.get("vehicle_color"),
+        event_data.get("plate_color"),
+        event_data.get("image_filename"), # This will be set by save_image_from_request
+        event_data.get("driving_direction"),
+        event_data.get("vehicle_speed"),
+        event_data.get("lane")
+    )
+
+    sql = f'''INSERT INTO anpr_events ({', '.join(sql_columns)})
+             VALUES ({', '.join(['%s'] * len(sql_columns))})'''
+
     try:
-        plate_num_cleaned = event_data.get("PlateNumber", "").strip()
-        data_tuple = (
-            event_data.get("Timestamp"), plate_num_cleaned, event_data.get("EventType"),
-            event_data.get("CameraID"), event_data.get("VehicleType"),
-            event_data.get("VehicleColor"), event_data.get("PlateColor"),
-            event_data.get("ImageFilename"), event_data.get("DrivingDirection")
-        )
-
-        cursor = DB_CONNECTION.cursor()
+        cursor = conn.cursor()
         cursor.execute(sql, data_tuple)
-        DB_CONNECTION.commit()
-        logger.info(f"Event for plate '{plate_num_cleaned}' inserted successfully. DB Row ID: {cursor.lastrowid}")
+        conn.commit()
+        row_id = cursor.lastrowid
+        logger.info(f"Event for plate '{event_data.get('plate_number')}' inserted successfully. DB Row ID: {row_id}")
         cursor.close()
-
+        return True
     except mysql.connector.Error as e:
-        logger.error(f"Error inserting into DB: {e}. Data: {event_data}", exc_info=True)
+        logger.error(f"Error inserting event into DB: {e}. Data: {event_data}", exc_info=True)
+        conn.rollback() # Rollback on error
+        return False
+    except Exception as e_gen:
+        logger.error(f"Generic error during event insertion: {e_gen}. Data: {event_data}", exc_info=True)
+        if conn and conn.is_connected(): conn.rollback()
+        return False
 
-def save_image(image_buffer, camera_id, timestamp_utc, plate_number):
-    if image_buffer and len(image_buffer) > 0:
-        image_uuid = uuid.uuid4()
-        ts_for_fn = f"{timestamp_utc.dwYear:04d}{timestamp_utc.dwMonth:02d}{timestamp_utc.dwDay:02d}_{timestamp_utc.dwHour:02d}{timestamp_utc.dwMinute:02d}{timestamp_utc.dwSecond:02d}"
+
+def save_image_from_request(image_file, event_data):
+    """Saves the image from the request and returns the filename, or None."""
+    if not image_file:
+        logger.info("No image file provided with the event.")
+        return None
+
+    try:
+        # Parse timestamp from event_data to use in filename
+        # Assuming timestamp_capture is in ISO format: "YYYY-MM-DDTHH:MM:SS.ffffff"
+        ts_iso = event_data.get("timestamp_capture")
+        if ts_iso:
+            dt_object = datetime.datetime.fromisoformat(ts_iso)
+            # Format for filename, e.g., YYYYMMDD_HHMMSS_ms
+            ts_for_fn = dt_object.strftime("%Y%m%d_%H%M%S_%f")[:-3] # Keep milliseconds
+        else:
+            # Fallback if timestamp is missing, though it shouldn't be
+            ts_for_fn = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:-3]
+            logger.warning("Timestamp missing in event_data for image naming, using current time.")
+
+        camera_id = sanitize_filename(event_data.get("camera_id", "UNKNOWN_CAM"))
+        plate_number = sanitize_filename(event_data.get("plate_number", "NO_PLATE"))
+        image_uuid = uuid.uuid4().hex[:8] # Shorter UUID
         
-        # Sanitize plate number for filename
-        sanitized_plate = sanitize_filename(plate_number)
-        
-        image_basename = f"{ts_for_fn}_{camera_id}_{sanitized_plate}_{image_uuid}.jpg"
+        image_basename = f"{ts_for_fn}_{camera_id}_{plate_number}_{image_uuid}.jpg"
         img_fn_with_path = os.path.join(IMAGE_DIR, image_basename)
-        try:
-            with open(img_fn_with_path, "wb") as f_img:
-                f_img.write(image_buffer)
-            logger.info(f"Image saved: {img_fn_with_path}")
-            return image_basename
-        except IOError as img_e:
-            logger.error(f"Error saving image {img_fn_with_path}: {img_e}")
-    return None
 
-def close_db_connection():
+        image_file.save(img_fn_with_path) # Flask FileStorage object has a save method
+        logger.info(f"Image saved: {img_fn_with_path}")
+        return image_basename
+    except Exception as e:
+        logger.error(f"Error saving image: {e}", exc_info=True)
+        return None
+
+@app.route('/event', methods=['POST'])
+def handle_event():
+    logger.info(f"Received event request. Headers: {request.headers}, Form keys: {list(request.form.keys())}, Files: {list(request.files.keys())}")
+
+    if 'event_data' not in request.form:
+        logger.error("Missing 'event_data' in form submission.")
+        return jsonify({"status": "error", "message": "Missing event_data"}), 400
+
+    try:
+        event_data_json = request.form['event_data']
+        event_data = json.loads(event_data_json)
+        logger.debug(f"Received event_data (JSON): {event_data}")
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to decode event_data JSON: {e}. Data: {request.form.get('event_data')}")
+        return jsonify({"status": "error", "message": "Invalid JSON in event_data"}), 400
+    except Exception as e_gen:
+        logger.error(f"Error processing form data: {e_gen}")
+        return jsonify({"status": "error", "message": "Error processing form data"}), 500
+
+    image_file = request.files.get('image') # Get image if present
+
+    # Save image first, get filename
+    image_filename = save_image_from_request(image_file, event_data)
+    event_data['image_filename'] = image_filename # Add/update image_filename in event_data
+
+    # Insert event into database
+    if insert_anpr_event_db(event_data):
+        logger.info(f"Successfully processed event for plate: {event_data.get('plate_number', 'N/A')}")
+        return jsonify({"status": "success", "message": "Event processed"}), 201
+    else:
+        logger.error(f"Failed to insert event into DB for plate: {event_data.get('plate_number', 'N/A')}")
+        # Potentially delete saved image if DB insert fails? For now, keeping it simple.
+        return jsonify({"status": "error", "message": "Failed to save event to database"}), 500
+
+@app.route('/health', methods=['GET'])
+def health_check():
+    db_connected = False
+    table_exists = False
+    conn = get_db_connection()
+
+    if conn and conn.is_connected():
+        db_connected = True
+        try:
+            cursor = conn.cursor()
+            # Check if the anpr_events table exists
+            # Using database name from env/default to qualify table name if needed, though usually not if DB is selected.
+            cursor.execute(f"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '{DB_NAME}' AND table_name = 'anpr_events'")
+            if cursor.fetchone()[0] == 1:
+                table_exists = True
+            else:
+                logger.warning(f"Health check: Table 'anpr_events' does not exist in database '{DB_NAME}'.")
+            cursor.close()
+        except mysql.connector.Error as e:
+            logger.error(f"Health check: Database error while checking for table: {e}")
+            db_connected = False # If query fails, consider DB not fully healthy for this check
+        except Exception as e_gen:
+            logger.error(f"Health check: Generic error while checking for table: {e_gen}")
+            db_connected = False # Treat generic errors as a problem too
+
+    if db_connected and table_exists:
+        return jsonify({"status": "healthy", "database_connection": "ok", "anpr_events_table": "exists"}), 200
+    elif db_connected and not table_exists:
+        return jsonify({"status": "unhealthy", "database_connection": "ok", "anpr_events_table": "missing"}), 503
+    else: # db_connected is False
+        return jsonify({"status": "unhealthy", "database_connection": "error", "anpr_events_table": "unknown"}), 503
+
+def close_db_connection_on_exit():
     global DB_CONNECTION
     if DB_CONNECTION and DB_CONNECTION.is_connected():
         DB_CONNECTION.close()
-        logger.info("MariaDB connection closed.")
-        DB_CONNECTION = None
+        logger.info("MariaDB connection closed on application exit.")
+
+if __name__ == '__main__':
+    if not initialize_database():
+        logger.warning("Database initialization failed. API might not function correctly for DB operations.")
+        # Decide if the app should exit or run with limited functionality
+        # For now, it will run, but DB operations will likely fail until DB is up.
+
+    import atexit
+    atexit.register(close_db_connection_on_exit)
+
+    # Port should be configurable, e.g., via environment variable
+    server_port = int(os.getenv('FLASK_RUN_PORT', 5001))
+    logger.info(f"Starting ANPR DB Manager Flask server on port {server_port}...")
+    # For development, use Flask's built-in server.
+    # For production, Gunicorn will be specified in docker-compose.yml or another process manager.
+    app.run(host='0.0.0.0', port=server_port, debug=False) # debug=False for production-like behavior

--- a/app/anpr_listener.py
+++ b/app/anpr_listener.py
@@ -5,168 +5,264 @@ import sys
 import time
 import datetime
 import json
+import logging
+import configparser
+import requests # Added for sending data to anpr_db_manager
 from ctypes import POINTER, cast, c_ubyte
+from threading import Thread # Added for non-blocking send_event_data
 
 from NetSDK.NetSDK import NetClient
 from NetSDK.SDK_Struct import *
 from NetSDK.SDK_Enum import *
 from NetSDK.SDK_Callback import *
 
-# --- CONFIGURACIÓN DE CÁMARAS ---
-USER_NAME = b"admin"
-PASSWORD = b"lb37AhH7zjzODf."
-PORT = 37777
-
-CAMERAS = [
-    {"ip": "10.45.14.11", "login_id": 0, "attach_id": 0},
-    {"ip": "10.45.14.12", "login_id": 0, "attach_id": 0},
-]
-
+# --- Global Variables ---
 g_attach_handle_map = {}
-LOG_FILE = "anpr.log"
-PACKET_LOG_FILE = "event_packets.log"
+CONFIG_FILE = 'config.ini' # Expect config.ini in the same directory or /app/
+DB_MANAGER_URL = os.getenv('DB_MANAGER_URL', 'http://anpr-db-manager:5001/event') # URL for anpr_db_manager
+
+# --- Logging Setup ---
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+log_formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
+
+# Console Handler
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setFormatter(log_formatter)
+logger.addHandler(console_handler)
+
+# File Handler (will be configured in main after reading config)
+file_handler = None
+
+
+def load_config():
+    """Loads configuration from config.ini."""
+    config = configparser.ConfigParser(interpolation=None)
+    # Try reading from /app/config.ini first (for Docker)
+    if not config.read(os.path.join('/app', CONFIG_FILE)):
+        # Fallback to local directory (for local testing)
+        if not config.read(CONFIG_FILE):
+            logger.error(f"Configuration file {CONFIG_FILE} not found in /app or current directory.")
+            sys.exit(1)
+
+    cameras = []
+    for section in config.sections():
+        if section.startswith("CAM"):
+            if config.getboolean(section, "Enabled", fallback=False):
+                cameras.append({
+                    "id": section,
+                    "ip": config.get(section, "IPAddress"),
+                    "port": config.getint(section, "Port", fallback=37777),
+                    "username": config.get(section, "Username").encode(), # SDK expects bytes
+                    "password": config.get(section, "Password").encode(), # SDK expects bytes
+                    "channel": config.getint(section, "Channel", fallback=0),
+                    "login_id": 0, # Placeholder for SDK login handle
+                    "attach_id": 0 # Placeholder for SDK event attach handle
+                })
+
+    log_file_path = config.get('General', 'LogFile', fallback='/app/logs/anpr_listener.log')
+    # Ensure log directory exists
+    os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+
+    global file_handler
+    if file_handler: # Remove existing file handler if any (e.g., during a config reload)
+        logger.removeHandler(file_handler)
+    file_handler = logging.FileHandler(log_file_path)
+    file_handler.setFormatter(log_formatter)
+    logger.addHandler(file_handler)
+
+    logger.info(f"Loaded {len(cameras)} enabled cameras from {CONFIG_FILE}.")
+    return cameras, log_file_path
+
+def send_event_data_async(event_data, image_buffer):
+    """Sends event data and image to anpr_db_manager in a separate thread."""
+    thread = Thread(target=send_event_data, args=(event_data, image_buffer))
+    thread.start()
+
+def send_event_data(event_data, image_buffer):
+    """
+    Sends event data and image (if available) to the anpr_db_manager service.
+    """
+    try:
+        files = {}
+        if image_buffer:
+            files['image'] = ('event_image.jpg', image_buffer, 'image/jpeg')
+
+        payload = {'event_data': json.dumps(event_data)}
+
+        logger.debug(f"Sending data to {DB_MANAGER_URL}. Payload keys: {payload.keys()}, Files: {files is not None}")
+        response = requests.post(DB_MANAGER_URL, files=files, data=payload, timeout=10)
+        response.raise_for_status() # Raises an HTTPError for bad responses (4XX or 5XX)
+        logger.info(f"Event data for plate {event_data.get('plate_number', 'N/A')} sent successfully to anpr_db_manager. Response: {response.status_code}")
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to send event data to anpr_db_manager: {e}", exc_info=True)
+    except Exception as e:
+        logger.error(f"An unexpected error occurred in send_event_data: {e}", exc_info=True)
+
 
 # --- FUNCIÓN CALLBACK PARA PROCESAR EVENTOS ---
-
 @CB_FUNCTYPE(None, C_LLONG, C_DWORD, c_void_p, POINTER(c_ubyte), C_DWORD, C_LDWORD, c_int, c_void_p)
 def analyzer_data_callback(lAnalyzerHandle, dwAlarmType, pAlarmInfo, pBuffer, dwBufSize, dwUser, nSequence, reserved):
     """
     Esta función se ejecuta cada vez que la cámara envía un evento de tráfico.
     """
     if dwAlarmType == EM_EVENT_IVS_TYPE.TRAFFICJUNCTION:
-        
         alarm_info = cast(pAlarmInfo, POINTER(DEV_EVENT_TRAFFICJUNCTION_INFO)).contents
+        camera_ip = g_attach_handle_map.get(lAnalyzerHandle, "Unknown IP")
 
-        # --- Bloque 1: Logging de campos clave del paquete ---
         try:
             utc = alarm_info.UTC
-            event_time = datetime.datetime(utc.dwYear, utc.dwMonth, utc.dwDay, utc.dwHour, utc.dwMinute, utc.dwSecond)
+            event_time = datetime.datetime(utc.dwYear, utc.dwMonth, utc.dwDay,
+                                           utc.dwHour, utc.dwMinute, utc.dwSecond, utc.dwMillisecond * 1000) # Include milliseconds
             
-            packet_details = {
-                "timestamp_capture": datetime.datetime.now().isoformat(),
-                "camera_ip": g_attach_handle_map.get(lAnalyzerHandle, "Unknown IP"),
-                "event_time_utc": event_time.isoformat(),
-                "plate_number": alarm_info.stTrafficCar.szPlateNumber.decode('gb2312', errors='ignore').strip(),
-                "vehicle_color": alarm_info.stTrafficCar.szVehicleColor.decode('gb2312', errors='ignore').strip(),
-                "vehicle_speed": alarm_info.stTrafficCar.nSpeed,
-                "lane": alarm_info.stTrafficCar.nLane
+            plate_number = alarm_info.stTrafficCar.szPlateNumber.decode('gb2312', errors='ignore').strip()
+            vehicle_color = alarm_info.stTrafficCar.szVehicleColor.decode('gb2312', errors='ignore').strip() # Example, map to standard later
+            plate_color = alarm_info.stTrafficCar.szPlateColor.decode('gb2312', errors='ignore').strip()     # Example
+            vehicle_type = alarm_info.stTrafficCar.szVehicleType.decode('gb2312', errors='ignore').strip() # Example
+            
+            # Determine driving direction (0: Approach, 1: Leave, 2: Unknown)
+            direction_map = {0: "Approach", 1: "Leave", 2: "Unknown"}
+            driving_direction = direction_map.get(alarm_info.stTrafficCar.emDrivingDirection, "Unknown")
+
+            event_details = {
+                "timestamp_capture": event_time.isoformat(),
+                "camera_id": camera_ip, # Or a more specific camera ID from config if available
+                "plate_number": plate_number,
+                "vehicle_color": vehicle_color,
+                "plate_color": plate_color,
+                "vehicle_type": vehicle_type,
+                "vehicle_speed": alarm_info.stTrafficCar.nSpeed, # km/h
+                "lane": alarm_info.stTrafficCar.nLane,
+                "event_type": "TrafficJunction", # From dwAlarmType
+                "driving_direction": driving_direction
+                # Potentially add more fields from alarm_info.stTrafficCar if needed
             }
-            
-            with open(PACKET_LOG_FILE, "a") as f:
-                f.write(json.dumps(packet_details, indent=4) + "\n---\n")
 
-        except Exception as e:
-            print(f"!!! ERROR writing to packet log: {e}")
+            logger.info(f"Plate Detected: {plate_number} by {camera_ip} at {event_time.strftime('%Y-%m-%d %H:%M:%S')}")
 
-        # --- Bloque 3: Guardado de la imagen ---
-        try:
+            image_bytes = None
             if pBuffer and dwBufSize > 0:
-                plate_number = alarm_info.stTrafficCar.szPlateNumber.decode('gb2312', errors='ignore').strip()
-                camera_ip = g_attach_handle_map.get(lAnalyzerHandle, "UnknownIP")
-                
-                utc = alarm_info.UTC
-                event_time = datetime.datetime(utc.dwYear, utc.dwMonth, utc.dwDay, utc.dwHour, utc.dwMinute, utc.dwSecond)
-                
-                # Crear un nombre de archivo único
-                time_str = event_time.strftime("%Y%m%d_%H%M%S")
-                filename = f"{time_str}_{camera_ip.replace('.', '-')}_{plate_number}.jpg"
-                filepath = os.path.join("capturas", filename)
+                image_bytes = pBuffer[:dwBufSize]
+                logger.debug(f"Image captured for plate {plate_number}, size: {dwBufSize} bytes.")
+            else:
+                logger.warning(f"No image buffer received for plate {plate_number} from {camera_ip}")
 
-                # Guardar el búfer de la imagen en el archivo
-                with open(filepath, "wb") as f:
-                    f.write(pBuffer[:dwBufSize])
-                
-                print(f"  -> Image saved to {filepath}")
+            # Send data (including image if available) to anpr_db_manager
+            send_event_data_async(event_details, image_bytes)
 
         except Exception as e:
-            print(f"!!! ERROR saving image: {e}")
-
-        # --- Bloque 2: Lógica original de detección de matrículas ---
-        try:
-            plate_number = alarm_info.stTrafficCar.szPlateNumber.decode('gb2312').strip()
-            camera_ip = g_attach_handle_map.get(lAnalyzerHandle, "Unknown IP")
-            
-            utc = alarm_info.UTC
-            event_time = datetime.datetime(utc.dwYear, utc.dwMonth, utc.dwDay, utc.dwHour, utc.dwMinute, utc.dwSecond)
-            time_str = event_time.strftime("%Y-%m-%d %H:%M:%S")
-
-            log_message = f"[{time_str}] [{camera_ip}] Plate Detected: {plate_number}"
-            print(log_message)
-            
-            with open(LOG_FILE, "a") as f:
-                f.write(log_message + "\n")
-
-        except Exception as e:
-            print(f"Error processing plate data: {e}")
+            logger.error(f"Error processing event from {camera_ip}: {e}", exc_info=True)
 
 # --- FUNCIÓN PRINCIPAL ---
-
 def main():
-    print("Initializing SDK...")
+    global CAMERAS # Allow main to modify the global CAMERAS list if needed for runtime changes
+
+    CAMERAS, _ = load_config() # Load camera configurations
+
+    if not CAMERAS:
+        logger.error("No enabled cameras found in configuration. Exiting.")
+        sys.exit(1)
+
+    logger.info("Initializing Dahua NetSDK...")
     sdk = NetClient()
     
-    log_info = LOG_SET_PRINT_INFO()
-    log_info.dwSize = sizeof(LOG_SET_PRINT_INFO)
-    log_info.bSetFilePath = 1
-    log_path = os.path.join(os.getcwd(), "sdk_debug.log").encode('gbk')
-    log_info.szLogFilePath = log_path
-    sdk.LogOpen(log_info)
-    print(f"SDK logging enabled. Log file: {log_path.decode()}")
+    # Configure SDK logging (optional, but useful for debugging SDK issues)
+    log_info_sdk = LOG_SET_PRINT_INFO()
+    log_info_sdk.dwSize = sizeof(LOG_SET_PRINT_INFO)
+    log_info_sdk.bSetFilePath = 1
+    # It's good practice to use a dedicated log for SDK, possibly configured via config.ini too
+    sdk_log_path_str = os.path.join(os.path.dirname(load_config()[1]), "netsdk_debug.log")
+    os.makedirs(os.path.dirname(sdk_log_path_str), exist_ok=True)
+    sdk_log_path_bytes = sdk_log_path_str.encode('gbk') # SDK might expect gbk for paths
+    log_info_sdk.szLogFilePath = sdk_log_path_bytes
+    if not sdk.LogOpen(log_info_sdk):
+        logger.warning(f"Failed to open SDK log file at {sdk_log_path_str}. Error: {sdk.GetLastError()}")
+    else:
+        logger.info(f"SDK logging enabled. Log file: {sdk_log_path_str}")
 
-    sdk.InitEx(None)
+    if not sdk.InitEx(None): # Pass a disconnect callback if needed
+        logger.critical(f"SDK InitEx failed. Error: {sdk.GetLastError()}")
+        sys.exit(1)
     
-    print("Connecting to cameras and subscribing to traffic events...")
+    logger.info("SDK Initialized. Connecting to cameras and subscribing to traffic events...")
 
-    for cam in CAMERAS:
+    for cam_config in CAMERAS:
         stuInParam = NET_IN_LOGIN_WITH_HIGHLEVEL_SECURITY()
         stuInParam.dwSize = sizeof(NET_IN_LOGIN_WITH_HIGHLEVEL_SECURITY)
-        stuInParam.szIP = cam["ip"].encode()
-        stuInParam.nPort = PORT
-        stuInParam.szUserName = USER_NAME
-        stuInParam.szPassword = PASSWORD
+        stuInParam.szIP = cam_config["ip"].encode() # IP from config
+        stuInParam.nPort = cam_config["port"]       # Port from config
+        stuInParam.szUserName = cam_config["username"] # Username from config
+        stuInParam.szPassword = cam_config["password"] # Password from config
         stuInParam.emSpecCap = EM_LOGIN_SPAC_CAP_TYPE.TCP
         
         stuOutParam = NET_OUT_LOGIN_WITH_HIGHLEVEL_SECURITY()
         stuOutParam.dwSize = sizeof(NET_OUT_LOGIN_WITH_HIGHLEVEL_SECURITY)
 
-        login_id, _, error_msg = sdk.LoginWithHighLevelSecurity(stuInParam, stuOutParam)
+        login_id, device_info, error_msg = sdk.LoginWithHighLevelSecurity(stuInParam, stuOutParam)
         
         if login_id != 0:
-            cam["login_id"] = login_id
-            print(f"  - Login SUCCESS: {cam['ip']}")
+            cam_config["login_id"] = login_id
+            logger.info(f"  - Login SUCCESS: {cam_config['ip']} (Camera ID: {cam_config['id']})")
             
-            channel = 0
-            bNeedPicFile = 1 # <--- CAMBIO CLAVE: 1 para solicitar la imagen
+            channel = cam_config["channel"] # Channel from config
+            bNeedPicFile = 1 # Request picture file
             
-            attach_id = sdk.RealLoadPictureEx(login_id, channel, EM_EVENT_IVS_TYPE.TRAFFICJUNCTION, bNeedPicFile, analyzer_data_callback, 0, None)
+            # The last parameter (dwUser) can be used to pass custom data (like camera_id) to the callback
+            # For simplicity, g_attach_handle_map is used here.
+            attach_id = sdk.RealLoadPictureEx(login_id, channel, EM_EVENT_IVS_TYPE.TRAFFICJUNCTION,
+                                              bNeedPicFile, analyzer_data_callback, 0, None)
             
             if attach_id != 0:
-                cam["attach_id"] = attach_id
-                g_attach_handle_map[attach_id] = cam["ip"]
-                print(f"  - Subscription SUCCESS: {cam['ip']}")
+                cam_config["attach_id"] = attach_id
+                g_attach_handle_map[attach_id] = cam_config["ip"] # Store IP, could also store cam_config['id']
+                logger.info(f"  - Subscription SUCCESS for traffic events: {cam_config['ip']} (Attach ID: {attach_id})")
             else:
-                print(f"  - Subscription FAILED: {cam['ip']} - Error: {sdk.GetLastError()}")
+                logger.error(f"  - Subscription FAILED for {cam_config['ip']}: Error {sdk.GetLastError()}")
                 sdk.Logout(login_id)
-                cam["login_id"] = 0
+                cam_config["login_id"] = 0 # Reset login_id
         else:
-            print(f"  - Login FAILED: {cam['ip']} - {error_msg}")
+            # Ensure error_msg is decoded if it's bytes, or handle appropriately
+            error_details = error_msg.decode('gbk', errors='ignore') if isinstance(error_msg, bytes) else str(error_msg)
+            logger.error(f"  - Login FAILED: {cam_config['ip']} (Camera ID: {cam_config['id']}) - Error: {error_details} (SDK Error Code: {sdk.GetLastError()})")
 
-    print("\n--- System is running. Waiting for license plate events. Press Ctrl+C to exit. ---")
+
+    active_cameras = [c for c in CAMERAS if c["attach_id"] != 0]
+    if not active_cameras:
+        logger.error("No cameras successfully subscribed. Exiting.")
+        sdk.Cleanup()
+        sys.exit(1)
+
+    logger.info(f"\n--- System is running. Monitoring {len(active_cameras)} camera(s). Press Ctrl+C to exit. ---")
     try:
         while True:
-            time.sleep(1)
+            # Keep main thread alive. Could add periodic checks or re-login logic here if needed.
+            time.sleep(5)
+            # Example: Check if any camera needs re-login (advanced)
+            # for cam_config in CAMERAS:
+            #     if cam_config["login_id"] != 0 and not sdk.IsConnected(cam_config["login_id"]): # Fictional IsConnected
+            #         logger.warning(f"Camera {cam_config['ip']} disconnected. Attempting to re-login...")
+            #         # Implement re-login logic
+            #         pass
+
     except KeyboardInterrupt:
-        print("\n--- Shutting down ---")
+        logger.info("\n--- User initiated shutdown (Ctrl+C) ---")
+    except Exception as e:
+        logger.error(f"An unexpected error occurred in the main loop: {e}", exc_info=True)
     finally:
-        for cam in CAMERAS:
-            if cam["attach_id"] != 0:
-                sdk.StopLoadPic(cam["attach_id"])
-                print(f"  - Unsubscribed from {cam['ip']}")
-            if cam["login_id"] != 0:
-                sdk.Logout(cam["login_id"])
-                print(f"  - Logged out from {cam['ip']}")
+        logger.info("--- Shutting down services and SDK ---")
+        for cam_config in CAMERAS:
+            if cam_config.get("attach_id", 0) != 0:
+                logger.info(f"  - Unsubscribing from {cam_config['ip']} (Attach ID: {cam_config['attach_id']})")
+                sdk.StopLoadPic(cam_config["attach_id"])
+            if cam_config.get("login_id", 0) != 0:
+                logger.info(f"  - Logging out from {cam_config['ip']}")
+                sdk.Logout(cam_config["login_id"])
+
+        logger.info("Cleaning up SDK resources...")
         sdk.Cleanup()
-        print("SDK cleaned up. Exiting.")
+        logger.info("SDK cleaned up. ANPR Listener stopped.")
 
 if __name__ == "__main__":
+    # Ensure the script's directory is in PYTHONPATH for imports if run directly
+    # sys.path.append(os.path.dirname(os.path.abspath(__file__)))
     main()

--- a/app/anpr_web.py
+++ b/app/anpr_web.py
@@ -1,0 +1,265 @@
+import os
+import sys
+import logging
+import configparser
+import datetime
+import math
+import mysql.connector
+from flask import Flask, jsonify, request, render_template, send_from_directory
+
+# --- Application Setup ---
+app = Flask(__name__, template_folder='templates')
+
+# --- Configuration Loading ---
+config = configparser.ConfigParser(interpolation=None)
+CONFIG_FILE_PATH = '/app/config.ini'  # Primary path for Docker
+if not os.path.exists(CONFIG_FILE_PATH):
+    CONFIG_FILE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.ini') # Fallback for local
+
+if not os.path.exists(CONFIG_FILE_PATH):
+    logging.basicConfig(level=logging.ERROR)
+    logging.error(f"CRITICAL: config.ini not found at /app/config.ini or local path. Please ensure it exists.")
+    sys.exit(1)
+config.read(CONFIG_FILE_PATH)
+
+# --- Global Variables & Paths from Config ---
+IMAGE_DIR = config.get('Paths', 'ImageDirectory', fallback='/app/anpr_images') # Default for Docker
+LOG_FILE_PATH = config.get('General', 'LogFile', fallback='/app/logs/anpr_web.log') # Default for Docker
+
+# Ensure log directory exists
+os.makedirs(os.path.dirname(LOG_FILE_PATH), exist_ok=True)
+
+# --- Logging Setup ---
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+log_formatter = logging.Formatter('%(asctime)s [%(levelname)s] [%(module)s:%(funcName)s:%(lineno)d] %(message)s')
+
+# File Handler
+file_handler = logging.FileHandler(LOG_FILE_PATH)
+file_handler.setFormatter(log_formatter)
+logger.addHandler(file_handler)
+
+# Console Handler
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setFormatter(log_formatter)
+logger.addHandler(console_handler)
+
+# --- Database Configuration ---
+DB_HOST = os.getenv('DB_HOST', 'mariadb')
+DB_USER = os.getenv('MYSQL_USER', 'anpr_user')
+DB_PASSWORD = os.getenv('MYSQL_PASSWORD')
+DB_NAME = os.getenv('MYSQL_DATABASE', 'anpr_events')
+
+if not DB_PASSWORD:
+    logger.critical("MYSQL_PASSWORD environment variable not set. Cannot connect to database.")
+    sys.exit(1)
+
+DB_CONNECTION = None
+
+def initialize_database():
+    global DB_CONNECTION
+    attempts = 0
+    max_attempts = 10
+    retry_delay = 5
+
+    while attempts < max_attempts:
+        try:
+            logger.info(f"Attempting to connect to database (Attempt {attempts + 1}/{max_attempts})...")
+            conn = mysql.connector.connect(
+                host=DB_HOST,
+                user=DB_USER,
+                password=DB_PASSWORD,
+                database=DB_NAME,
+                connection_timeout=10
+            )
+            if conn.is_connected():
+                logger.info(f"Successfully connected to MariaDB database: {DB_NAME} on {DB_HOST}")
+                DB_CONNECTION = conn
+                return True
+        except mysql.connector.Error as e:
+            logger.warning(f"Failed to connect to database: {e}. Retrying in {retry_delay} seconds...")
+            attempts += 1
+            import time # local import for sleep
+            time.sleep(retry_delay)
+
+    logger.critical("Could not connect to the database after multiple attempts.")
+    return False
+
+def get_db_connection():
+    global DB_CONNECTION
+    try:
+        if DB_CONNECTION is None or not DB_CONNECTION.is_connected():
+            logger.info("Database connection lost or not initialized. Attempting to reconnect...")
+            initialize_database()
+        else:
+            DB_CONNECTION.ping(reconnect=True, attempts=3, delay=1)
+            logger.debug("Database connection is active.")
+        return DB_CONNECTION
+    except mysql.connector.Error as e:
+        logger.error(f"Database connection check failed: {e}. Attempting to re-initialize.")
+        initialize_database()
+        return DB_CONNECTION
+
+# --- Routes ---
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/images/<path:filename>')
+def serve_image(filename):
+    logger.debug(f"Attempting to serve image: {filename} from directory: {IMAGE_DIR}")
+    return send_from_directory(IMAGE_DIR, filename)
+
+@app.route('/api/events', methods=['GET'])
+def get_events():
+    conn = get_db_connection()
+    if not conn or not conn.is_connected():
+        logger.error("No database connection for /api/events")
+        return jsonify({"error": "Database connection failed"}), 500
+
+    try:
+        page = int(request.args.get('page', 1))
+        limit = int(request.args.get('limit', 10))
+        offset = (page - 1) * limit
+
+        # Filters
+        filters = []
+        params = []
+
+        # String fields
+        for field in ['plate', 'camera_id', 'vehicle_type', 'vehicle_color', 'driving_direction']:
+            value = request.args.get(field)
+            if value:
+                # Map 'plate' from query to 'PlateNumber' in DB
+                db_field = 'PlateNumber' if field == 'plate' else field.replace('_', '') # Simple snake_case to PascalCase
+                # For exact match on CameraID, VehicleType, VehicleColor, DrivingDirection
+                if field in ['camera_id', 'vehicle_type', 'vehicle_color', 'driving_direction']:
+                     # Need to map field names from JS (snake_case) to DB (PascalCase)
+                    db_field_map = {
+                        'camera_id': 'CameraID',
+                        'vehicle_type': 'VehicleType',
+                        'vehicle_color': 'VehicleColor',
+                        'driving_direction': 'DrivingDirection'
+                    }
+                    filters.append(f"{db_field_map.get(field, field)} = %s")
+                else: # For plate number, use LIKE
+                    filters.append(f"{db_field} LIKE %s")
+                    value = f"%{value}%"
+                params.append(value)
+
+        # Date fields
+        start_date_str = request.args.get('start_date')
+        end_date_str = request.args.get('end_date')
+
+        if start_date_str:
+            filters.append("Timestamp >= %s")
+            params.append(start_date_str)
+        if end_date_str:
+            filters.append("Timestamp <= %s")
+            params.append(end_date_str)
+
+        where_clause = " AND ".join(filters) if filters else "1=1"
+
+        # Count total events for pagination
+        count_query = f"SELECT COUNT(*) FROM anpr_events WHERE {where_clause}"
+        cursor = conn.cursor()
+        cursor.execute(count_query, tuple(params))
+        total_events = cursor.fetchone()[0]
+        total_pages = math.ceil(total_events / limit)
+
+        # Fetch events for the current page
+        query = f"""
+            SELECT Timestamp, PlateNumber, EventType, CameraID, VehicleType, VehicleColor, PlateColor, ImageFilename, DrivingDirection, VehicleSpeed, Lane
+            FROM anpr_events
+            WHERE {where_clause}
+            ORDER BY Timestamp DESC
+            LIMIT %s OFFSET %s
+        """
+        cursor.execute(query, tuple(params + [limit, offset]))
+
+        events = []
+        columns = [col[0] for col in cursor.description]
+        for row in cursor.fetchall():
+            event = dict(zip(columns, row))
+            # Format Timestamp as ISO string or desired format
+            if isinstance(event.get('Timestamp'), datetime.datetime):
+                event['Timestamp'] = event['Timestamp'].isoformat(sep=' ', timespec='milliseconds')
+            events.append(event)
+
+        cursor.close()
+
+        return jsonify({
+            "events": events,
+            "current_page": page,
+            "total_pages": total_pages,
+            "total_events": total_events
+        })
+
+    except mysql.connector.Error as e:
+        logger.error(f"Database error in /api/events: {e}", exc_info=True)
+        return jsonify({"error": "Database query failed"}), 500
+    except Exception as e:
+        logger.error(f"Unexpected error in /api/events: {e}", exc_info=True)
+        return jsonify({"error": "An unexpected error occurred"}), 500
+
+
+@app.route('/api/cameras', methods=['GET'])
+def get_cameras():
+    conn = get_db_connection()
+    if not conn or not conn.is_connected():
+        return jsonify({"error": "Database connection failed"}), 500
+
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT DISTINCT CameraID FROM anpr_events WHERE CameraID IS NOT NULL AND CameraID != '' ORDER BY CameraID")
+        cameras = [row[0] for row in cursor.fetchall()]
+        cursor.close()
+        return jsonify({"cameras": cameras})
+    except mysql.connector.Error as e:
+        logger.error(f"Database error in /api/cameras: {e}", exc_info=True)
+        return jsonify({"error": "Database query failed"}), 500
+    except Exception as e:
+        logger.error(f"Unexpected error in /api/cameras: {e}", exc_info=True)
+        return jsonify({"error": "An unexpected error occurred"}), 500
+
+@app.route('/api/events/latest_timestamp', methods=['GET'])
+def get_latest_event_timestamp():
+    conn = get_db_connection()
+    if not conn or not conn.is_connected():
+        return jsonify({"error": "Database connection failed"}), 500
+
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT MAX(Timestamp) FROM anpr_events")
+        latest_ts_db = cursor.fetchone()[0]
+        cursor.close()
+
+        latest_timestamp_iso = None
+        if latest_ts_db and isinstance(latest_ts_db, datetime.datetime):
+            latest_timestamp_iso = latest_ts_db.isoformat(sep=' ', timespec='milliseconds')
+
+        return jsonify({"latest_timestamp": latest_timestamp_iso})
+    except mysql.connector.Error as e:
+        logger.error(f"Database error in /api/events/latest_timestamp: {e}", exc_info=True)
+        return jsonify({"error": "Database query failed"}), 500
+    except Exception as e:
+        logger.error(f"Unexpected error in /api/events/latest_timestamp: {e}", exc_info=True)
+        return jsonify({"error": "An unexpected error occurred"}), 500
+
+def close_db_connection_on_exit():
+    global DB_CONNECTION
+    if DB_CONNECTION and DB_CONNECTION.is_connected():
+        DB_CONNECTION.close()
+        logger.info("MariaDB connection closed on application exit.")
+
+if __name__ == '__main__':
+    if not initialize_database():
+        logger.warning("Database initialization failed. API might not function correctly for DB operations.")
+
+    import atexit
+    atexit.register(close_db_connection_on_exit)
+
+    server_port = int(os.getenv('FLASK_RUN_PORT', 5000)) # Default port 5000 for web UI
+    logger.info(f"Starting ANPR Web UI Flask server on port {server_port}...")
+    app.run(host='0.0.0.0', port=server_port, debug=False) # debug=False for production-like

--- a/app/config.ini.example
+++ b/app/config.ini.example
@@ -1,5 +1,7 @@
 [General]
-LogFile = /app/logs/anpr_events.log
+# LogFile setting is no longer used here.
+# Each service (listener, db_manager, web) defaults to its own log file
+# (e.g., anpr_listener.log) within the /app/logs/ directory volume.
 
 [Paths]
 ImageDirectory = /app/anpr_images

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,72 +1,100 @@
 # docker-compose.yml
-# Final version: 2025-07-08
-# This file orchestrates the ANPR listener, web UI, MariaDB, and Cloudflare tunnel as separate services.
+# This file orchestrates the ANPR listener, DB manager, web UI, MariaDB, and Cloudflare tunnel.
 version: '3.8'
 
 services:
-  # Service 1: The ANPR listener
-  # This container runs the get_plates.py script to listen for camera events.
   anpr-listener:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: anpr_listener_service
     env_file: .env
+    environment:
+      - DB_MANAGER_URL=http://anpr-db-manager:5001/event
+      # Add any other specific environment variables for the listener if needed
     restart: always
+    # WORKDIR /app is set in Dockerfile
     command: python anpr_listener.py
     volumes:
-      - ./app/anpr_images:/app/anpr_images
-      - ./app/logs:/app/logs
       - ./app/config.ini:/app/config.ini:ro
+      - ./app/logs:/app/logs
+      # anpr-listener does not save images directly anymore, anpr_images volume removed from here
+    depends_on:
+      - anpr-db-manager # Listener needs DB manager to be available to send events
+
+  anpr-db-manager:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: anpr_db_manager_service
+    env_file: .env
+    environment:
+      - FLASK_RUN_PORT=5001
+      # MYSQL_USER, MYSQL_PASSWORD, MYSQL_DATABASE, DB_HOST are in .env
+    restart: always
+    # WORKDIR /app is set in Dockerfile
+    command: gunicorn --bind 0.0.0.0:5001 --workers 2 --timeout 120 anpr_db_manager:app
+    volumes:
+      - ./app/config.ini:/app/config.ini:ro
+      - ./app/anpr_images:/app/anpr_images # For saving received images
+      - ./app/logs:/app/logs
     depends_on:
       mariadb:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:5001/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s # Give time for Flask app and DB connection to initialize
 
-  # Service 2: The Web Interface
-  # This container runs the Flask app with Gunicorn.
   anpr-web-ui:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: anpr_web_ui_service
     env_file: .env
+    environment:
+      - FLASK_RUN_PORT=5000
+      # MYSQL_USER, MYSQL_PASSWORD, MYSQL_DATABASE, DB_HOST are in .env
     restart: always
-    command: gunicorn --bind 0.0.0.0:5000 --workers 2 --timeout 120 app:app
+    # WORKDIR /app is set in Dockerfile
+    command: gunicorn --bind 0.0.0.0:5000 --workers 2 --timeout 120 anpr_web:app
     ports:
-      - "5000:5000"
+      - "5000:5000" # Expose port 5000 for Cloudflared and local access
     volumes:
-      - ./app/anpr_images:/app/anpr_images:ro
       - ./app/config.ini:/app/config.ini:ro
+      - ./app/anpr_images:/app/anpr_images:ro # Read-only access to images
+      - ./app/logs:/app/logs
+      # ./app/templates is part of the image, no need to mount unless actively developing templates
     depends_on:
-      - anpr-listener
-      - mariadb
+      mariadb:
+        condition: service_healthy
+      anpr-db-manager: # Add dependency on anpr-db-manager
+        condition: service_healthy # Wait for anpr-db-manager to be healthy
 
-  # Service 3: The Cloudflare Tunnel
-  # This service creates a secure tunnel to the web interface.
   cloudflared-tunnel:
     image: cloudflare/cloudflared:latest
-    container_name: anpr_tunnel
+    container_name: anpr_tunnel_service # Renamed for consistency
     restart: always
+    # Token should be in .env file, which is loaded by cloudflared if command is just 'tunnel run'
+    # Or explicitly pass: tunnel --no-autoupdate run --token ${CLOUDFLARE_TOKEN}
     command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TOKEN}
     depends_on:
-      - anpr-web-ui
+      - anpr-web-ui # Tunnel should start after the web UI is available
 
-  # Service 4: MariaDB Database
   mariadb:
     image: mariadb:10.6
-    container_name: anpr_mariadb
+    container_name: anpr_mariadb_service # Renamed for consistency
     restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    env_file: .env # MYSQL_ROOT_PASSWORD, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD
     volumes:
-      - ./app/db:/var/lib/mysql
+      - anpr_db_data:/var/lib/mysql # Use a named volume for DB data persistence
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "${MYSQL_USER}", "-p${MYSQL_PASSWORD}"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-volumes: {}
+volumes:
+  anpr_db_data: # Define the named volume for MariaDB

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+requests
+mysql-connector-python
+gunicorn


### PR DESCRIPTION
- Dockerfile: Refactored Dahua SDK installation to better leverage Docker cache by copying the .whl file to a temporary location before installation and performing all SDK setup in a single RUN layer.
- anpr_db_manager.py: Enhanced the /health endpoint to check for both database connectivity and the existence of the 'anpr_events' table. Returns HTTP 200 only if both conditions are true, otherwise 503.
- docker-compose.yml: Added a healthcheck to the anpr-db-manager service utilizing the updated /health endpoint. The anpr-web-ui service now depends_on anpr-db-manager (service_healthy) to ensure correct startup order and prevent errors related to table non-existence.