### PR TITLE
Fix: Ensure anpr-db-manager healthy before anpr-web-ui starts

### DIFF
--- a/app/anpr_db_manager.py
+++ b/app/anpr_db_manager.py
@@ -1,27 +1,35 @@
 import time, sys, logging, os, re, configparser, uuid
 import mysql.connector
+from flask import Flask, jsonify, request # Added Flask imports
+
+# --- Flask App Initialization ---
+app = Flask(__name__) # Gunicorn expects an 'app' object
 
 # --- Configuration Loading ---
 config = configparser.ConfigParser(interpolation=None)
-# Assuming config.ini will be in the same directory as anpr_poc.py or specified via an absolute path
-# For now, let's assume it's relative to where the script is run or we'll need to adjust this path.
-# For a robust solution, consider passing the config path or making it configurable.
-# For this PoC, we'll assume it's in the same directory as anpr_poc.py for simplicity.
-config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.ini')
+config_path = '/app/config.ini' # Standard path in Docker container
 if not os.path.exists(config_path):
-    # Fallback for development/testing if config.ini is not in the same dir
-    config_path = '/app/config.ini' # Path used in anpr-camera-listener Docker setup
-    if not os.path.exists(config_path):
-        logging.error(f"config.ini not found at {os.path.dirname(os.path.abspath(__file__))} or /app/. Please ensure it exists.")
-        sys.exit(1)
+    # Fallback for local development if /app/config.ini isn't there
+    alt_config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.ini')
+    if os.path.exists(alt_config_path):
+        config_path = alt_config_path
+    else:
+        logging.basicConfig(level=logging.ERROR)
+        logger_fallback = logging.getLogger(__name__)
+        logger_fallback.error(f"CRITICAL: config.ini not found at /app/config.ini or {alt_config_path}. Please ensure it exists.")
+        sys.exit(1) # Critical error, cannot proceed without config
 
 config.read(config_path)
 
-IMAGE_DIR = config.get('Paths', 'ImageDirectory', fallback=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'capturas'))
-LOG_FILE = config.get('General', 'LogFile', fallback=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'anpr_events.log'))
+IMAGE_DIR = config.get('Paths', 'ImageDirectory', fallback='/app/anpr_images') # Docker path
+LOG_DIR = config.get('General', 'LogDirectory', fallback='/app/logs') # Docker path
+LOG_FILE = os.path.join(LOG_DIR, 'anpr_db_manager.log') # Specific log file for this service
 
-# Ensure IMAGE_DIR exists
+
+# Ensure IMAGE_DIR and LOG_DIR exist
 os.makedirs(IMAGE_DIR, exist_ok=True)
+os.makedirs(LOG_DIR, exist_ok=True)
+
 
 # --- Database Configuration ---
 DB_HOST = os.getenv('DB_HOST', 'mariadb')
@@ -30,41 +38,58 @@ DB_PASSWORD = os.getenv('MYSQL_PASSWORD')
 DB_NAME = os.getenv('MYSQL_DATABASE', 'anpr_events')
 
 # --- Logging Setup ---
-log_formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
-# Ensure log directory exists before setting up handler
-if LOG_FILE:
-    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+log_formatter = logging.Formatter('%(asctime)s [%(levelname)s] [%(module)s:%(funcName)s:%(lineno)d] %(message)s')
+
+# File Handler
 file_handler = logging.FileHandler(LOG_FILE)
 file_handler.setFormatter(log_formatter)
-file_handler.setLevel(logging.INFO)
+
+# Console Handler
 console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setFormatter(log_formatter)
-console_handler.setLevel(logging.INFO)
-logger = logging.getLogger(__name__) # Use __name__ for logger
+
+# Configure Flask's logger and the script's logger
+logger = logging.getLogger(__name__) # For general script logging
+app.logger.handlers = [] # Clear default Flask handlers
+app.logger.propagate = False # Prevent Flask logs from going to root logger if not desired
+
+for handler in [file_handler, console_handler]:
+    logger.addHandler(handler)
+    app.logger.addHandler(handler) # Add our handlers to Flask's logger
+
 logger.setLevel(logging.INFO)
-if not logger.handlers: # Prevent adding multiple handlers if already configured
-    logger.addHandler(file_handler)
-    logger.addHandler(console_handler)
+app.logger.setLevel(logging.INFO)
+
+if not DB_PASSWORD:
+    logger.critical("CRITICAL: MYSQL_PASSWORD environment variable not set. Database operations will fail.")
+    # Don't exit here, let health check fail
 
 DB_CONNECTION = None
+TABLE_INITIALIZED = False # Flag to track if table creation was successful
 
 def sanitize_filename(name_part):
     if not name_part or name_part == "N/A": return "NO_PLATE"
     return re.sub(r'[\\/*?:"<>|]', "_", name_part)
 
-def initialize_database():
-    global DB_CONNECTION
+def initialize_database(is_startup=False):
+    global DB_CONNECTION, TABLE_INITIALIZED
     attempts = 0
-    while attempts < 10:
+    # On startup, be more persistent. For runtime reconnections, fewer attempts might be desired.
+    max_attempts = 10 if is_startup else 3
+    retry_delay = 5
+
+    while attempts < max_attempts:
         try:
+            logger.info(f"Attempting to connect to database (Attempt {attempts + 1}/{max_attempts})...")
             conn = mysql.connector.connect(
                 host=DB_HOST,
                 user=DB_USER,
                 password=DB_PASSWORD,
-                database=DB_NAME
+                database=DB_NAME,
+                connection_timeout=10 # Added connection timeout
             )
             if conn.is_connected():
-                logger.info("Successfully connected to MariaDB database.")
+                logger.info(f"Successfully connected to MariaDB database: {DB_NAME} on {DB_HOST}")
                 DB_CONNECTION = conn
                 try:
                     logger.info("Ensuring anpr_events table exists...")
@@ -81,6 +106,8 @@ def initialize_database():
                             PlateColor VARCHAR(255),
                             ImageFilename VARCHAR(255),
                             DrivingDirection VARCHAR(255),
+                            VehicleSpeed INT,             -- Added from anpr_web.py
+                            Lane VARCHAR(50),             -- Added from anpr_web.py
                             ReceivedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                             INDEX idx_plate_number (PlateNumber),
                             INDEX idx_camera_id (CameraID),
@@ -91,69 +118,205 @@ def initialize_database():
                         )
                     """)
                     DB_CONNECTION.commit()
+                    # Verify table creation for health check
+                    cursor.execute(f"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '{DB_NAME}' AND table_name = 'anpr_events'")
+                    if cursor.fetchone()[0] == 1:
+                        TABLE_INITIALIZED = True
+                        logger.info("Table anpr_events ensured and verified.")
+                    else:
+                        TABLE_INITIALIZED = False
+                        logger.error("Failed to verify anpr_events table creation.")
                     cursor.close()
-                    logger.info("Table anpr_events ensured.")
                 except mysql.connector.Error as err_table:
+                    TABLE_INITIALIZED = False
                     logger.error(f"Failed to create/ensure anpr_events table: {err_table}")
-                return
+                return True # Connection successful
         except mysql.connector.Error as e:
-            logger.warning(f"Failed to connect to database: {e}. Retrying in 5 seconds...")
+            logger.warning(f"Failed to connect to database: {e}. Retrying in {retry_delay} seconds...")
             attempts += 1
-            time.sleep(5)
+            time.sleep(retry_delay)
     
-    logger.critical("Could not connect to the database after multiple attempts. Exiting.")
-    sys.exit(1)
+    logger.critical(f"Could not connect to the database after {max_attempts} attempts.")
+    if is_startup and not DB_CONNECTION: # Only exit if it's a startup failure and no connection was ever made
+        # For Gunicorn, exiting might lead to worker restarts. Health check will handle unhealthiness.
+        # sys.exit(1) # Removed sys.exit to allow Gunicorn to manage the process
+        pass
+    return False # Connection failed
 
-def insert_anpr_event_db(event_data):
-    if DB_CONNECTION is None or not DB_CONNECTION.is_connected():
-        logger.warning("DB_CONNECTION is not available. Attempting to reconnect...")
-        initialize_database()
-        if DB_CONNECTION is None or not DB_CONNECTION.is_connected():
-            logger.error("Failed to re-establish database connection. Cannot insert event.")
-            return
-
-    sql = '''INSERT INTO anpr_events (Timestamp, PlateNumber, EventType, CameraID, VehicleType, VehicleColor, PlateColor, ImageFilename, DrivingDirection)
-             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)'''
+def get_db_connection():
+    global DB_CONNECTION
     try:
-        plate_num_cleaned = event_data.get("PlateNumber", "").strip()
+        if DB_CONNECTION is None or not DB_CONNECTION.is_connected():
+            logger.warning("DB_CONNECTION is not available or not connected. Attempting to reconnect...")
+            initialize_database(is_startup=False) # Attempt to reconnect with fewer retries
+
+        if DB_CONNECTION and DB_CONNECTION.is_connected():
+            # Optional: Ping the server to ensure connection is live before returning
+            # DB_CONNECTION.ping(reconnect=True, attempts=1, delay=1)
+            return DB_CONNECTION
+        else:
+            logger.error("Failed to re-establish database connection.")
+            return None
+    except mysql.connector.Error as e:
+        logger.error(f"Database connection check/ping failed: {e}. Attempting to re-initialize.")
+        initialize_database(is_startup=False)
+        return DB_CONNECTION # Return whatever state it's in (might be None)
+
+
+@app.route('/event', methods=['POST'])
+def receive_event():
+    """
+    Receives ANPR event data (assumed to be JSON) and an image (optional).
+    Saves the image and stores event details in the database.
+    This endpoint is intended to be called by anpr_listener.
+    """
+    conn = get_db_connection()
+    if not conn:
+        return jsonify({"status": "error", "message": "Database connection unavailable"}), 503
+
+    try:
+        event_data = request.json
+        if not event_data:
+            return jsonify({"status": "error", "message": "No JSON data received"}), 400
+
+        logger.info(f"Received event data: {event_data}")
+
+        # Image saving logic - assuming image might be sent separately or path provided
+        # For this manager, we'll assume image is already saved and filename is in event_data
+        # or that anpr_listener is responsible for placing it where anpr_web can find it.
+        # This DB manager's primary role is to log the event metadata.
+        # If anpr-listener sends image data to this endpoint, it needs to be handled (e.g. request.files)
+
+        image_filename = event_data.get("ImageFilename") # Expecting filename from listener
+
+        # If ImageFilename is not provided, but image data could be, handle here.
+        # For now, we rely on ImageFilename.
+
+        insert_anpr_event_db(event_data, image_filename, conn) # Pass conn
+
+        return jsonify({"status": "success", "message": "Event processed"}), 201
+
+    except Exception as e:
+        logger.error(f"Error processing event: {e}", exc_info=True)
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+def insert_anpr_event_db(event_data, image_filename_from_event, db_conn): # Added db_conn parameter
+    # This function is now called by the /event endpoint, db_conn should be valid.
+    if not db_conn or not db_conn.is_connected():
+        logger.error("Cannot insert event, database connection is not valid.")
+        # Optionally, try to reconnect once more, but the endpoint should handle this.
+        return False
+
+
+    # Ensure all expected fields are present, providing defaults or handling missing data
+    sql = '''INSERT INTO anpr_events
+             (Timestamp, PlateNumber, EventType, CameraID, VehicleType, VehicleColor, PlateColor,
+              ImageFilename, DrivingDirection, VehicleSpeed, Lane)
+             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)'''
+    try:
+        plate_num_cleaned = event_data.get("PlateNumber", "N/A").strip()
         data_tuple = (
-            event_data.get("Timestamp"), plate_num_cleaned, event_data.get("EventType"),
-            event_data.get("CameraID"), event_data.get("VehicleType"),
-            event_data.get("VehicleColor"), event_data.get("PlateColor"),
-            event_data.get("ImageFilename"), event_data.get("DrivingDirection")
+            event_data.get("Timestamp"),
+            plate_num_cleaned,
+            event_data.get("EventType"),
+            event_data.get("CameraID"),
+            event_data.get("VehicleType"),
+            event_data.get("VehicleColor"),
+            event_data.get("PlateColor"),
+            image_filename_from_event, # Use the filename passed to the function
+            event_data.get("DrivingDirection"),
+            event_data.get("VehicleSpeed"), # Added
+            event_data.get("Lane")          # Added
         )
 
-        cursor = DB_CONNECTION.cursor()
+        cursor = db_conn.cursor()
         cursor.execute(sql, data_tuple)
-        DB_CONNECTION.commit()
+        db_conn.commit()
         logger.info(f"Event for plate '{plate_num_cleaned}' inserted successfully. DB Row ID: {cursor.lastrowid}")
         cursor.close()
+        return True
 
     except mysql.connector.Error as e:
         logger.error(f"Error inserting into DB: {e}. Data: {event_data}", exc_info=True)
+        # Consider if a rollback is needed if part of a larger transaction
+        return False
 
-def save_image(image_buffer, camera_id, timestamp_utc, plate_number):
-    if image_buffer and len(image_buffer) > 0:
-        image_uuid = uuid.uuid4()
-        ts_for_fn = f"{timestamp_utc.dwYear:04d}{timestamp_utc.dwMonth:02d}{timestamp_utc.dwDay:02d}_{timestamp_utc.dwHour:02d}{timestamp_utc.dwMinute:02d}{timestamp_utc.dwSecond:02d}"
 
-        # Sanitize plate number for filename
-        sanitized_plate = sanitize_filename(plate_number)
-        
-        image_basename = f"{ts_for_fn}_{camera_id}_{sanitized_plate}_{image_uuid}.jpg"
-        img_fn_with_path = os.path.join(IMAGE_DIR, image_basename)
-        try:
-            with open(img_fn_with_path, "wb") as f_img:
-                f_img.write(image_buffer)
-            logger.info(f"Image saved: {img_fn_with_path}")
-            return image_basename
-        except IOError as img_e:
-            logger.error(f"Error saving image {img_fn_with_path}: {img_e}")
-    return None
+# save_image function seems more appropriate for anpr_listener or a shared utility if needed here.
+# For anpr_db_manager, it primarily stores event data.
+# If anpr_listener calls this service with image data, then save_image would be relevant here.
+# Based on current setup, anpr_listener saves image then calls anpr_web, which calls this.
+# Let's assume anpr_listener might also directly call db_manager with event data that includes ImageFilename.
 
-def close_db_connection():
+# def save_image(image_buffer, camera_id, timestamp_utc, plate_number):
+#     # This function is identical to the one in anpr_listener.
+#     # If this service is also responsible for saving images, it needs to be called.
+#     # For now, assuming image_filename is provided in the event_data.
+#     pass
+
+
+@app.route('/health', methods=['GET'])
+def health_check():
+    global TABLE_INITIALIZED
+    db_connected = False
+    table_ok = TABLE_INITIALIZED # Use the flag set during/after initialize_database
+
+    conn = get_db_connection() # This will attempt to connect/reconnect if necessary
+
+    if conn and conn.is_connected():
+        db_connected = True
+        # Double check table status if connection was just (re)established and TABLE_INITIALIZED is false
+        if not table_ok:
+            try:
+                cursor = conn.cursor()
+                cursor.execute(f"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '{DB_NAME}' AND table_name = 'anpr_events'")
+                if cursor.fetchone()[0] == 1:
+                    table_ok = True
+                    TABLE_INITIALIZED = True # Update global flag
+                    logger.info("Health check: Table 'anpr_events' confirmed to exist.")
+                else:
+                    logger.warning("Health check: Table 'anpr_events' still not found.")
+                cursor.close()
+            except mysql.connector.Error as e:
+                logger.error(f"Health check: Database error while re-checking for table: {e}")
+                # table_ok remains false
+            except Exception as e_gen:
+                 logger.error(f"Health check: Generic error while re-checking for table: {e_gen}")
+    else: # conn is None or not connected
+        db_connected = False
+        table_ok = False # If no DB connection, table cannot be confirmed.
+
+    if db_connected and table_ok:
+        return jsonify({"status": "healthy", "database_connection": "ok", "anpr_events_table": "exists"}), 200
+    elif db_connected and not table_ok:
+        # This state means DB is connected, but table creation failed or is pending.
+        # Critical for service readiness.
+        return jsonify({"status": "unhealthy", "database_connection": "ok", "anpr_events_table": "missing_or_failed"}), 503
+    else: # db_connected is False
+        return jsonify({"status": "unhealthy", "database_connection": "error", "anpr_events_table": "unknown"}), 503
+
+
+def close_db_connection_on_exit(): # Renamed to be more specific
     global DB_CONNECTION
     if DB_CONNECTION and DB_CONNECTION.is_connected():
         DB_CONNECTION.close()
-        logger.info("MariaDB connection closed.")
+        logger.info("MariaDB connection closed on application exit.")
         DB_CONNECTION = None
+
+# Initialize database at application startup (when Gunicorn loads the app)
+# This is crucial for the health check to pass eventually.
+initialize_database(is_startup=True)
+
+import atexit
+atexit.register(close_db_connection_on_exit)
+
+if __name__ == '__main__':
+    # This block is for direct execution (python anpr_db_manager.py)
+    # Gunicorn will use the 'app' object directly.
+    # Ensure DB is initialized if running directly.
+    # initialize_database() was already called globally for Gunicorn.
+
+    server_port = int(os.getenv('FLASK_RUN_PORT', 5001))
+    logger.info(f"Starting ANPR DB Manager Flask server directly on http://0.0.0.0:{server_port}...")
+    app.run(host='0.0.0.0', port=server_port, debug=False) # debug=False for production/gunicorn consistency

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,12 +95,14 @@ services:
     restart: always
     env_file: .env # MYSQL_ROOT_PASSWORD, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD
     volumes:
-      - anpr_db_data:/var/lib/mysql # Use a named volume for DB data persistence
+      - ./app/db:/var/lib/mysql # Use bind mount for DB data persistence in ./app/db
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "${MYSQL_USER}", "-p${MYSQL_PASSWORD}"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-volumes:
-  anpr_db_data: # Define the named volume for MariaDB
+# Named volume anpr_db_data is no longer used for MariaDB, can be removed if not used by other services.
+# For now, let's comment it out or remove it if confirmed it's not needed elsewhere.
+# volumes:
+#   anpr_db_data: # Define the named volume for MariaDB

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ NC='\033[0m' # No Color
 APP_DIR="app"
 IMAGE_DIR_HOST="${APP_DIR}/anpr_images" # Path on the host for images
 LOG_DIR_HOST="${APP_DIR}/logs"         # Path on the host for logs
-DB_DATA_VOLUME_NAME="anpr_db_data"     # Named volume for MariaDB data
+DB_DIR_HOST="${APP_DIR}/db"            # Path on the host for MariaDB data (bind mount)
 DEPS_MARKER_FILE="${LOG_DIR_HOST}/.dependencies_checked" # Marker file for dependency installation
 SDK_TEMP_DIR=".sdk_temp"
 ENV_FILE=".env"
@@ -318,6 +318,16 @@ case $COMMAND in
         mkdir -p "${IMAGE_DIR_HOST}"
         # Ensure LOG_DIR_HOST again just in case install_dependencies was skipped due to marker
         mkdir -p "${LOG_DIR_HOST}"
+
+        # Check and create DB_DIR_HOST
+        if [ ! -d "${DB_DIR_HOST}" ]; then
+            echo -e "${YELLOW}Database directory (${DB_DIR_HOST}) not found. Creating it...${NC}"
+            mkdir -p "${DB_DIR_HOST}"
+            echo -e "${GREEN}Database directory ${DB_DIR_HOST} created successfully.${NC}"
+        else
+            echo -e "${GREEN}Using existing database directory: ${DB_DIR_HOST}.${NC}"
+        fi
+
         echo "--- Building and starting services... ---"
         $COMPOSE_CMD up --build -d
         echo -e "${GREEN}--- Services started successfully. ---${NC}"
@@ -350,23 +360,23 @@ case $COMMAND in
 
         if [ "$FORCE_CLEAN" = true ]; then
             echo -e "${YELLOW}--- Force cleaning environment... ---${NC}"
-            echo "Stopping and removing containers, and the MariaDB named volume (${DB_DATA_VOLUME_NAME})..."
-            $COMPOSE_CMD down -v # Removes containers and anonymous volumes
-            docker volume rm "${DB_DATA_VOLUME_NAME}" 2>/dev/null || echo -e "${YELLOW}Volume ${DB_DATA_VOLUME_NAME} not found or already removed.${NC}"
+            echo "Stopping and removing containers..."
+            $COMPOSE_CMD down -v # Removes containers and anonymous volumes (though we don't have anonymous for DB anymore)
 
-            echo "Deleting data from host-mounted log and image directories (${IMAGE_DIR_HOST}, ${LOG_DIR_HOST})..."
+            echo "Deleting data from host-mounted directories (${IMAGE_DIR_HOST}, ${LOG_DIR_HOST}, ${DB_DIR_HOST})..."
             rm -rf "${IMAGE_DIR_HOST}/"*
             rm -rf "${LOG_DIR_HOST}/"* # This will also remove the .dependencies_checked marker
+            rm -rf "${DB_DIR_HOST}/"*
             # Recreate dirs after cleaning
-            mkdir -p "${IMAGE_DIR_HOST}" "${LOG_DIR_HOST}"
-            echo -e "${GREEN}--- All services, containers, MariaDB named volume, and host image/log data have been removed. ---${NC}"
+            mkdir -p "${IMAGE_DIR_HOST}" "${LOG_DIR_HOST}" "${DB_DIR_HOST}"
+            echo -e "${GREEN}--- All services, containers, and host-mounted data (images, logs, database) have been cleared. ---${NC}"
             echo -e "${YELLOW}Note: The .dependencies_checked marker has been removed; system dependencies will be re-checked on next relevant command.${NC}"
         else
             echo -e "${RED}WARNING: This will stop all services and remove containers.${NC}"
-            echo -e "${RED}You will also be asked if you want to permanently delete:${NC}"
+            echo -e "${RED}You will also be asked if you want to permanently delete data from:${NC}"
             echo -e "${RED}  - Captured images in ${IMAGE_DIR_HOST}"
             echo -e "${RED}  - Log files in ${LOG_DIR_HOST} (including the .dependencies_checked marker)"
-            echo -e "${RED}  - The MariaDB database volume ('${DB_DATA_VOLUME_NAME}')"
+            echo -e "${RED}  - The MariaDB database files in ${DB_DIR_HOST}"
             read -p "Are you sure you want to stop services and remove containers? (y/N) " -n 1 -r
             echo
             if [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -374,24 +384,19 @@ case $COMMAND in
                 $COMPOSE_CMD down -v # -v also removes anonymous volumes
                 echo -e "${GREEN}--- Services stopped and containers removed. ---${NC}"
 
-                read -p "Do you also want to delete all data in ${IMAGE_DIR_HOST}, ${LOG_DIR_HOST}, and the MariaDB volume (${DB_DATA_VOLUME_NAME})? This is IRREVERSIBLE. (y/N) " -n 1 -r
+                read -p "Do you also want to delete all data in ${IMAGE_DIR_HOST}, ${LOG_DIR_HOST}, and ${DB_DIR_HOST}? This is IRREVERSIBLE. (y/N) " -n 1 -r
                 echo
                 if [[ $REPLY =~ ^[Yy]$ ]]; then
-                    echo "Deleting ${IMAGE_DIR_HOST}/*, ${LOG_DIR_HOST}/*..."
+                    echo "Deleting contents of ${IMAGE_DIR_HOST}, ${LOG_DIR_HOST}, ${DB_DIR_HOST}..."
                     rm -rf "${IMAGE_DIR_HOST}/"*
                     rm -rf "${LOG_DIR_HOST}/"* # This removes the .dependencies_checked marker too
-                    mkdir -p "${IMAGE_DIR_HOST}" "${LOG_DIR_HOST}" # Recreate dirs
+                    rm -rf "${DB_DIR_HOST}/"*
+                    mkdir -p "${IMAGE_DIR_HOST}" "${LOG_DIR_HOST}" "${DB_DIR_HOST}" # Recreate dirs
 
-                    echo "Attempting to remove MariaDB volume: ${DB_DATA_VOLUME_NAME}..."
-                    if docker volume rm "${DB_DATA_VOLUME_NAME}" 2>/dev/null; then
-                        echo -e "${GREEN}MariaDB volume '${DB_DATA_VOLUME_NAME}' removed successfully.${NC}"
-                    else
-                        echo -e "${YELLOW}MariaDB volume '${DB_DATA_VOLUME_NAME}' not found or could not be removed (it might not exist if services never ran or were already cleaned).${NC}"
-                    fi
                     echo -e "${GREEN}--- All specified application data has been removed. ---${NC}"
                     echo -e "${YELLOW}Note: The .dependencies_checked marker has been removed; system dependencies will be re-checked on next relevant command.${NC}"
                 else
-                    echo -e "${YELLOW}--- Application data (images, logs, DB volume) remains. ---${NC}"
+                    echo -e "${YELLOW}--- Application data (images, logs, DB files) remains. ---${NC}"
                 fi
             else
                 echo "--- Clean operation cancelled. ---"


### PR DESCRIPTION
- Modified anpr_db_manager.py to be a Flask app with a /health endpoint that verifies DB connection and anpr_events table creation.
- anpr_db_manager now initializes DB & table on startup.
- Updated docker-compose.yml to use a bind mount (./app/db) for MariaDB data persistence, ensuring data is visible on the host.
- Updated setup.sh to manage the ./app/db directory (create if not exists, notify you) and to correctly clean this directory.
- Verified docker-compose.yml dependencies to ensure anpr-web-ui waits for a healthy anpr-db-manager.
- Reviewed anpr_web.py's /health endpoint; no changes needed there as the root cause was service startup order and db_manager readiness.